### PR TITLE
[Do not merge] Gradle: Optional Checker Running

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 plugins {
+<<<<<<< Updated upstream
   id "base"
   id "com.palantir.consistent-versions" version "2.11.0"
   id "org.owasp.dependencycheck" version "8.0.1"
@@ -28,6 +29,18 @@ plugins {
   id "net.ltgt.errorprone" version "3.0.1" apply false
   id 'com.diffplug.spotless' version "6.5.2" apply false
   id 'com.github.node-gradle.node' version '3.4.0' apply false
+=======
+  id 'base'
+  id 'com.palantir.consistent-versions' version '2.16.0'
+  id 'org.owasp.dependencycheck' version '8.4.0'
+  id 'ca.cutterslade.analyze' version '1.9.1'
+  id 'de.thetaphi.forbiddenapis' version '3.6' apply false
+  id 'de.undercouch.download' version '5.5.0' apply false
+  id 'net.ltgt.errorprone' version '3.1.0' apply false
+  id 'com.diffplug.spotless' version '6.5.2' apply false
+  id 'com.github.node-gradle.node' version '7.0.1' apply false
+  id 'org.checkerframework' version '0.6.35' apply false
+>>>>>>> Stashed changes
 }
 
 apply from: file('gradle/globals.gradle')
@@ -141,6 +154,7 @@ apply from: file('gradle/ide/eclipse.gradle')
 // Validation tasks
 apply from: file('gradle/validation/measure-task-times.gradle')
 apply from: file('gradle/validation/error-prone.gradle')
+apply from: file('gradle/validation/checkerframework.gradle')
 apply from: file('gradle/validation/precommit.gradle')
 apply from: file('gradle/validation/forbidden-apis.gradle')
 apply from: file('gradle/validation/jar-checks.gradle')

--- a/gradle/validation/checkerframework.gradle
+++ b/gradle/validation/checkerframework.gradle
@@ -1,0 +1,13 @@
+// Only apply checkerframework to java projects.
+allprojects { prj ->
+  plugins.withId("java", {
+    prj.apply plugin: 'org.checkerframework'
+    checkerFramework {
+      checkers = ['org.checkerframework.checker.optional.OptionalChecker']
+    }
+    dependencies {
+      checkerFramework 'org.checkerframework:checker:3.40.0'
+      implementation 'org.checkerframework:checker-qual:3.40.0'
+    }
+  })
+}

--- a/versions.lock
+++ b/versions.lock
@@ -269,10 +269,17 @@ org.carrot2:morfologik-fsa:2.1.9 (1 constraints: db0d9c36)
 org.carrot2:morfologik-polish:2.1.9 (1 constraints: d312541e)
 org.carrot2:morfologik-stemming:2.1.9 (2 constraints: d81fb300)
 org.ccil.cowan.tagsoup:tagsoup:1.2.1 (1 constraints: 5b0ce801)
+<<<<<<< Updated upstream
 org.checkerframework:checker-qual:3.33.0 (5 constraints: 57468bea)
 org.codehaus.janino:commons-compiler:3.1.8 (2 constraints: 2f1983ec)
 org.codehaus.janino:janino:3.1.8 (1 constraints: 640dbc2c)
 org.codehaus.woodstox:stax2-api:4.2.1 (2 constraints: 36152eaf)
+=======
+org.checkerframework:checker-qual:3.40.0 (5 constraints: 5c4694ee)
+org.codehaus.janino:commons-compiler:3.1.9 (2 constraints: 3119a8ec)
+org.codehaus.janino:janino:3.1.9 (1 constraints: 650dbd2c)
+org.codehaus.woodstox:stax2-api:4.2.2 (2 constraints: 37155caf)
+>>>>>>> Stashed changes
 org.codelibs:jhighlight:1.1.0 (1 constraints: 590ce401)
 org.conscrypt:conscrypt-openjdk-uber:2.5.2 (1 constraints: ed0fea95)
 org.eclipse.jetty:jetty-alpn-client:10.0.15 (3 constraints: f12e1a60)


### PR DESCRIPTION
No errors but interesting uses of `Optional`

For example, this line of code: https://github.com/apache/solr/blob/88dbe12873d0474f48e087194a33e8fc411849a9/solr/core/src/java/org/apache/solr/handler/designer/DefaultSchemaSuggester.java#L159

Is admitted, both by `javac` and the Optional Checker. However, the JDK docs for `Optional.of` says:

> Returns an Optional with the specified present non-null value.